### PR TITLE
give ArbitraryJoda.arbJoda a time zone

### DIFF
--- a/datetime/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
+++ b/datetime/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
@@ -109,5 +109,6 @@ trait GenJoda {
 object GenJoda extends GenJoda
 
 object ArbitraryJoda extends GenJoda {
-  implicit val arbJoda: Arbitrary[DateTime] = Arbitrary(genDateTime)
+  implicit def arbJoda(implicit zone: DateTimeZone = DateTimeZone.getDefault): Arbitrary[DateTime] =
+    Arbitrary(genDateTime.map(_.withZone(zone)))
 }

--- a/datetime/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
+++ b/datetime/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
@@ -76,7 +76,15 @@ object GenJodaProperties extends Properties("Joda Generators") {
   property("arbitrary generation creates valid DateTime instances (with no granularity)") = {
     import ArbitraryJoda._
     forAll { dt: DateTime =>
-      passed
+      dt.getZone == DateTimeZone.getDefault
+    }
+  }
+
+  property("arbitrary generation creates DateTime instances with right time zone") = {
+    implicit val zone = DateTimeZone.UTC
+    import ArbitraryJoda._
+    forAll { dt: DateTime =>
+      dt.getZone == zone
     }
   }
 


### PR DESCRIPTION
It was easy so I just did it. If you would rather it be handled differently, that's fine, just let me know.

I didn't add an `implicit val defaultTimeZone` because I ran into a problem with ambiguous implicits.

https://github.com/47deg/scalacheck-toolbox/issues/16