### PR TITLE
Updated sbt-org-policies version to 0.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.4
+  - 2.12.6
 
 before_install:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
@@ -38,7 +38,7 @@ jobs:
         - sbt ++$TRAVIS_SCALA_VERSION orgCheckSettings
         - sbt ++$TRAVIS_SCALA_VERSION docs/tut
         - bash <(curl -s https://codecov.io/bash)
-      scala: 2.12.4
+      scala: 2.12.6
     - stage: deploy
       script:
         - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
@@ -54,7 +54,7 @@ jobs:
               sbt docs/publishMicrosite;
             fi
           fi
-      scala: 2.12.4
+      scala: 2.12.6
 
 cache:
   directories:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.1")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.24")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.5-SNAPSHOT"
+version in ThisBuild := "0.2.5"


### PR DESCRIPTION
This PR updates the`sbt-org-policies` version to "0.9.1", also release scalacheck-toolbox v0.2.5